### PR TITLE
thud: default.xml: uprev meta-updater

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -17,7 +17,7 @@
   <project name="meta-openembedded" path="layers/meta-openembedded" remote="oe" revision="6094ae18c8a35e5cc9998ac39869390d7f3bb1e2"/>
   <project name="meta-toradex-bsp-common.git" path="layers/meta-toradex-bsp-common" remote="toradex-bsp" revision="master-next"/>
   <project name="meta-toradex-torizon" path="layers/meta-toradex-torizon" remote="toradex-torizon" revision="master"/>
-  <project name="meta-updater" path="layers/meta-updater" remote="ats" revision="f4e46ffa9992ee41cc6ac1dff71f2c9907290a81"/>
+  <project name="meta-updater" path="layers/meta-updater" remote="ats" revision="b1db05a11a66ab03714863a940604a7af531e996"/>
   <project name="meta-virtualization" path="layers/meta-virtualization" remote="yocto" revision="d56c5abfde02318666dde07e5ada0024b40a34d0"/>
   <project name="meta-yocto" path="layers/meta-yocto" remote="yocto" revision="e8de212ef932e6e837483517dff324aa9d9bbe5d">
     <linkfile dest="setup-environment" src="../../.repo/manifests/setup-environment"/>


### PR DESCRIPTION
Move the tip to b1db05a11a66ab03714863a940604a7af531e996:
```
    Merge pull request #462 from advancedtelematic/feat/latest-aktualizr

    aktualizr: bump to latest 1cad6d10286ade64b24021ca0e23de0d3b64f520
```

So far, the rocko/sumo/thud/master branches of meta-updater all bump to
aktualizr latest 1cad6d10286ade64b24021ca0e23de0d3b64f520, we do the
same.

Signed-off-by: Ming Liu <liu.ming50@gmail.com>